### PR TITLE
Fixed es_ES & pt_PT pack descriptions

### DIFF
--- a/GeyserFontFixer Fidelity/texts/es_ES.lang
+++ b/GeyserFontFixer Fidelity/texts/es_ES.lang
@@ -1,1 +1,1 @@
-pack.description=pack.description=§lArregla la fuente en Bedrock, Añadiendo Minusculas Y Nuevos Caracteres, lSoporte En discord.klisee.net
+pack.description=§lArregla la fuente en Bedrock, Añadiendo Minusculas Y Nuevos Caracteres, Soporte En discord.klisee.net

--- a/GeyserFontFixer Fidelity/texts/pt_PT.lang
+++ b/GeyserFontFixer Fidelity/texts/pt_PT.lang
@@ -1,1 +1,1 @@
-pack.description=pack.description=§lResolve A Fonte Bedrock, Adicionando Letras Minúsculas E Novos Caracteres, §Suporte Em discord.klisee.net
+pack.description=§lResolve A Fonte Bedrock, Adicionando Letras Minúsculas E Novos Caracteres, Suporte Em discord.klisee.net

--- a/GeyserFontFixer/texts/es_ES.lang
+++ b/GeyserFontFixer/texts/es_ES.lang
@@ -1,1 +1,1 @@
-pack.description=pack.description=§lArregla la fuente en Bedrock, Añadiendo Minusculas Y Nuevos Caracteres, lSoporte En discord.klisee.net
+pack.description=§lArregla la fuente en Bedrock, Añadiendo Minusculas Y Nuevos Caracteres, Soporte En discord.klisee.net

--- a/GeyserFontFixer/texts/pt_PT.lang
+++ b/GeyserFontFixer/texts/pt_PT.lang
@@ -1,1 +1,1 @@
-pack.description=pack.description=§lResolve A Fonte Bedrock, Adicionando Letras Minúsculas E Novos Caracteres, §Suporte Em discord.klisee.net
+pack.description=§lResolve A Fonte Bedrock, Adicionando Letras Minúsculas E Novos Caracteres, Suporte Em discord.klisee.net


### PR DESCRIPTION
They had `pack.description=` at the beginning of the string